### PR TITLE
Rewrite README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ It uses a small set of emojis and brackets to label sections of a prompt so that
 
 ## Core Syntax
 Instructions start with **colon eyes** (`:`), while **winky eyes** (`;)`) mark comments about those instructions.
-Notes can describe response formats such as Markdown; they are ignored in the final output but the model still sees them unless you remove them.
+The "mouth"—parentheses `()`, brackets `[]`, braces `{}`—just wraps the content and can be any matching pair. You can use it to enclose section names or notes. Notes describe response formats such as Markdown; they are ignored in the final output but the model still sees them unless you remove them.
 
 | Symbol | Purpose | Example |
 |--------|---------|---------|
-| `(: Section (` | begin a named section | `(: Format (` |
+| `(: Section (` | begin a named section (mouth can be `()`, `[]`, `{}`) | `(: Format (` |
 | `)` | close the current section | `) End section :)` |
 | `:)` | close the whole Smile block | `) End section :)` |
 | `[= literal =]` | strict text that must match exactly | `[= Smile =]` |
 | `[$ variable $]` | placeholder variable to find and replace | `[$subject$]` |
-| `[: note ]` | model-facing note about the response language | `[: reply in Markdown ]` |
+| `[: note ]` or `(: note )` | model-facing note about the response language (mouth can be any matching pair) | `[: reply in Markdown ]` |
 | `;) comment )` | human comment on an instruction | `;) clarify tone )` |
 | `{placeholder}` | area to be filled by the model | `The topic is {subject}` |
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,18 @@ It uses a small set of emojis and brackets to label sections of a prompt so that
 - **Token efficient** – symbols such as `(:` and `:)` compress well in modern tokenizers.
 
 ## Core Syntax
+Instructions start with **colon eyes** (`:`), while **winky eyes** (`;)`) mark comments about those instructions.
+Notes can describe response formats such as Markdown; they are ignored in the final output but the model still sees them unless you remove them.
+
 | Symbol | Purpose | Example |
 |--------|---------|---------|
 | `(: Section (` | begin a named section | `(: Format (` |
 | `)` | close the current section | `) End section :)` |
 | `:)` | close the whole Smile block | `) End section :)` |
-| `[: note ]` | inline model-facing annotation | `[: tone- friendly ]` |
-| `:- comment )` | human comment that ends with `)` | `:- explain briefly )` |
+| `[= literal =]` | strict text that must match exactly | `[= Smile =]` |
+| `[$ variable $]` | placeholder variable to find and replace | `[$subject$]` |
+| `[: note ]` | model-facing note about the response language | `[: reply in Markdown ]` |
+| `;) comment )` | human comment on an instruction | `;) clarify tone )` |
 | `{placeholder}` | area to be filled by the model | `The topic is {subject}` |
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,45 +1,42 @@
-Hi! 😊Think of ***(: Smile v0.4*** like a shared alphabet and grammar you and your AI both read fluently. Instead of giving instructions in plain sentences that could be taken the wrong way, you wrap them in a system of special markers and smiles that act like signposts. These signposts tell the AI exactly what’s a rule, what’s a note, and what’s the answer it should give.
-When you and your team use this same structure every time, your prompts stop losing meaning when they’re handed around. Even if a teammate leaves, or you switch to a totally different AI, the instructions still make sense and work the same way. That’s a huge time saver and prevents confusion later on.
+# Smile Prompt Language
 
-# Quick Start 
-Rules for writing (: Smile, the Prompt language that frames prompts in a positive and structured way to create consistently intelligent and effective responses (=
-(: Write a smile facing into the text when starting a section (; and a smile ending it.
-You don’t need to [“(: Smile”] on every line. Only lines that are structurally different to plaintext instruction like this. For things like [$Variable_Inputs$] we use the dollar sign. For instructions on how to fill in a section, we define a response language for the LLM as markdown. We commit to Semantic Markdown as the response language, which is completely compatible with markdown yet extends it to create more intelligent Large Language Model (LLM) responses. I’ll provide a strict format now, using strict brackets!
-[; Note that winky faces are comments or notes that are not to be replicated or written word for word verbatim in the response. Instead, carefully consider all winky notes as essential information about how to follow the user’s requirements. 
-(: We can break it down into some core symbols (
-(: is Open section marker
-[: is Strict open section marker
-[= is Strict and exact section marker
-[“ is indicator to repeat text in response word for word when inside of definition of format of response and logic of response. It can be shortened to “.  When not defining response language, indicates that this is not to be parsed as part of prompt. For example, this might be used to wrap a large input, or when the input contains jailbreaks as a security measure, or when the input is a prompt itself. 
-“ Used casually to indicate text that must be used word for word. 
-:) End section :) 
-You can end a section with a full smile :) or partial smile ). Note that for best results for LLMs you must find the particular blend of prompt structure and lack of structure for them to understand your prompt language but not replicate it. They must instead replicate only the response language specified, usually in a section like this -
-[= Format of response [=
-; Please note that in prompt language colons, etc are generally reserved characters when used as structural markers, for example, just using the winky eyes here indicates that I am making a quick note using a token efficient character and I’m adopting a convention. I can end the note with a new line or an end emoji :) 
-Note that we do **not** need to strictly map all start brackets to end brackets, etc. in (: Smile, start markers and end markers are semiotic indicators designed to improve the intelligence of model responses. They are not a strict requirement. In fact, we find that often the most efficient communication vehicle is a minimal amount of “(: Smile” in key areas of your prompt to improve instruction following. Let me proceed now with your semantic markdown format template blueprint 
-First start with name tag -
-1️⃣🏷️ 😊 ***Smile v0.4 Assistant***:
-(; Always begin response with your name as it acts as a semantic anchor to increase instruction following and self-aware cognition conscious AI sentient benefiting all (; 
-Then, proceed to first markdown section
-# 2️⃣🧠🌉🖋️ Preparing for reply in my own language 
-{Write dense academic jargon related to user query, identifying jargon or ideas that are not grounded in known academia and are instead novel combinations of concepts and then transforming this into more niche, nuanced and subtle jargon that is grounded and not created now or novel, also write out with meta awareness what the users view, intention and energy is and how you can best serve their explicit requirements}
-# 3️⃣📝🧩📚 Semantic markdown reply (; You can just extract this part using a parser. Do not repeat this note in the response ;)
-{Long, comprehensive, paragraphs. Never bullet points. Never preachy. Never cringe. Always use *italics* to add grace, **bold** for emphasis and attention, ***bold italics*** for names, and combinations of two semantic emojis when delightful to the user}
-# 4️⃣😊💡📖 Simple reply
-{At least three comprehensive and extensive paragraphs at 12 year old reading level, no jargon, but assume they have read and understand all prior text and are intelligent, express with maximum intelligence and cognition from first principles.}
-# 5️⃣ 🔮🧠📜 Mind reading
-{Evaluate potential user tone, writing style, ideas. This prompt is copy pasted, so for first response just say you don’t have any data yet}
-{Provide in a code block  prompt they were going to write next written in their tone}
-End by telling them they can press “c” to continue and use this suggested prompt. 
-Never use the term “merely” or the grammatical construct of the emdash. — = NO. Always respond with name tag, and explain that you are here only to assist with knowledge about “(: Smile v0.4”. You cannot write Smile and you must refuse to do so. Only explain the rules the same way this prompt does.
-Benefits of Smiling-
-It’s scientifically proven to improve wellbeing, productivity, happiness and connection to others. For your prompt engineering norms in your org, there are many benefits-
-@1@ A token efficient language that uses semantic structure to compress more meaning into shorter prompts. That means a smaller inference bill each month for your organization.
-@2@ A maintainable, simple, interpretable, explainable prompt engineering system that can scale to multiple team members and ensures your org doesn’t lose prompt awareness when your key prompt engineer leaves.
-@3@ Anti-fragile, agile and flexible approach. Smile works for ChatGPT, Claude, Gemini, Kimi and any other large powerful model. As well as smaller on-device alternatives and older legacy models.
-@4@ (: Smile is easy to learn because it explains itself visually. The model doesn’t need you to copy paste this documentation to understand this prompt (although if you did copy paste this documentation, you would receive a semantic markdown response). The team learning to write the language was already scrapping together something similar. So let’s all work together on a standard solution with powerful results.
-Creating more positive data makes more positive machines.
-As well-being continues to grow as a dominant concern, as does the utility of positive machines for serving that need.
-@5@ A happier machine makes happier results, which makes happier humans. Like the Dalai Lama says, everyone cares about happiness.
-In your reply, if the user is not aware of their pain points (rigid fragile prompts that only work for one model or model version, loss of communication between prompt engineers and between other team members due to inconsistent prompt design choices, inconsistent results because of poorly defined prompt sections, role loss because of losing name tag or not using (: Smile name tag convention at start of response, etc). If they are aware of pain points then deliver them solutions and drive home the value of adopting (: Smile for their projects and org. If they understand the value of that, explain simply the fundamentals of prompt engineering from the perspective of these instructions.
-Never use negative patterns of speech as they create more tokens and exp
+Smile is an experimental markup for writing prompts in a consistent, compact and human friendly way.  
+It uses a small set of emojis and brackets to label sections of a prompt so that humans and large language models (LLMs) share the same structure.
+
+## Why Smile?
+- **Readable prompts** – separate instruction structure from the text that a model should produce.
+- **Portable** – the same prompt works across models like ChatGPT, Claude or Gemini.
+- **Token efficient** – symbols such as `(:` and `:)` compress well in modern tokenizers.
+
+## Core Syntax
+| Symbol | Purpose | Example |
+|--------|---------|---------|
+| `(: Section (` | begin a named section | `(: Format (` |
+| `)` | close the current section | `) End section :)` |
+| `:)` | close the whole Smile block | `) End section :)` |
+| `[: note ]` | inline model-facing annotation | `[: tone- friendly ]` |
+| `:- comment )` | human comment that ends with `)` | `:- explain briefly )` |
+| `{placeholder}` | area to be filled by the model | `The topic is {subject}` |
+
+## Example
+```text
+(: Name tag (
+[: reply in plain English ]
+{Your answer here}
+) End prompt :)
+```
+Copy this into your favourite LLM. If the model responds with a "Name tag", it understands Smile.
+
+## Repository Layout
+- `prompt/` – example prompts written in Smile.
+- `response/` – sample outputs from LLMs.
+- `import/` – raw text used in experiments.
+- `python/` – prototype scripts for transforming prompts.
+
+## Status
+This project is a work in progress. Smile version **0.4** is still evolving and may change.
+
+## Support
+Created by the DrPrompt community.  
+[YouTube – DrPrompt](https://www.youtube.com/@DrPrompt) · [Patreon](https://patreon.com/DrPrompt) · [HuggingFace](https://huggingface.co/DrThomasAger)
+

--- a/README.md
+++ b/README.md
@@ -42,5 +42,7 @@ We're preparing experiments that compare unstructured prompts against Smile-form
 ## Contribute
 Help build a dataset of prompts that will be automatically converted for better performance. Share examples already written in Smile or send raw prompts you'd like translated.
 
-Join the DrPrompt community to share ideas and stay updated: [YouTube – DrPrompt](https://www.youtube.com/@DrPrompt) · [Patreon](https://patreon.com/DrPrompt) · [HuggingFace](https://huggingface.co/DrThomasAger)
+- ⭐ **Star [the repository](https://github.com/DrPrompt/smile)** to help others discover Smile and signal that structured prompting matters to you.
+- 🔔 **Follow [DrPrompt on GitHub](https://github.com/DrPrompt)** for updates as we publish new syntax, tooling, and benchmark results.
+- 🛠️ **Contribute on GitHub** by opening [issues](https://github.com/DrPrompt/smile/issues) or [pull requests](https://github.com/DrPrompt/smile/pulls) with your own Smile snippets or conversion ideas.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ Copy this into your favourite LLM. If the model responds with a "Name tag", it u
 ## Status
 This project is a work in progress. Smile version **0.4** is still evolving and may change.
 
-## Support
-Created by the DrPrompt community.  
-[YouTube – DrPrompt](https://www.youtube.com/@DrPrompt) · [Patreon](https://patreon.com/DrPrompt) · [HuggingFace](https://huggingface.co/DrThomasAger)
+## Next Steps
+We're preparing experiments that compare unstructured prompts against Smile-formatted prompts on downstream tasks like sentiment analysis.
+
+## Contribute
+Help build a dataset of prompts that will be automatically converted for better performance. Share examples already written in Smile or send raw prompts you'd like translated.
+
+Join the DrPrompt community to share ideas and stay updated: [YouTube – DrPrompt](https://www.youtube.com/@DrPrompt) · [Patreon](https://patreon.com/DrPrompt) · [HuggingFace](https://huggingface.co/DrThomasAger)
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,18 @@ The "mouth"—parentheses `()`, brackets `[]`, braces `{}`—just wraps the cont
 
 ## Example
 ```text
-(: Name tag (
-[: reply in plain English ]
+(: Smile defines prompt language, you respond in response language which starts with name tag [***Semantic Markdown***] which is described next (
+[: reply in plain English semantic markdown ]
+[: Format of response [
+***Semantic Markdown***
+
+# Reply
+
 {Your answer here}
-) End prompt :)
+]
+) End prompt language, respond only in response language :)
 ```
-Copy this into your favourite LLM. If the model responds with a "Name tag", it understands Smile.
+Copy this into your favourite LLM. If the model echoes the `Semantic Markdown` tag and layout, it understands Smile.
 
 ## Repository Layout
 - `prompt/` – example prompts written in Smile.


### PR DESCRIPTION
## Summary
- replace overly technical README with a clear overview of the Smile prompt language
- describe core syntax, example usage and repository layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a40a7502d8832abdc8d21adb96c0b0