### PR TITLE
Change Mistral's Le Chat to "closed" provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,9 @@ Want to quickly try ***(: Smile*** on a ***LLM?***
 | **Type**   | ✓ Link to copy & paste                                |
 |:----------:|:------------------------------------------|
 | **Open**   | [Kimi Chat (Moonshot AI)](https://www.kimi.com/) |
-|            | [Le Chat (Mistral)](https://chat.mistral.ai)     |
 | **Closed** | [ChatGPT (OpenAI)](https://chat.openai.com)      |
 |            | [Claude (Anthropic)](https://claude.ai/new)      |
-
+|            | [Le Chat (Mistral)](https://chat.mistral.ai)     |
 
 [: *Just copy and paste the quick start example into one of the chats above, or check [here](#portability-and-compatibility) for alternative options.*
 


### PR DESCRIPTION
Hey there,

this pull request changes the provider "Le Chat" by Mistral AI to the "closed" category in the `README.md`.

It fixes #6.

Thanks in advance!